### PR TITLE
Correct IPv6 nginx error

### DIFF
--- a/setup-debian.sh
+++ b/setup-debian.sh
@@ -420,14 +420,6 @@ END
 	echo 'Created /etc/nginx/sites-available/default_php sample vhost'
 	echo ' '
 
- if [ -f /etc/nginx/sites-available/default ]
-	then
-		# Made IPV6 Listener not conflict and throw errors
-		sed -i \
-			"s/listen \[::]:80 default_server;/listen [::]:80 default_server ipv6only=on;/" \
-			/etc/nginx/sites-available/default
- fi
-
  if [ -f /etc/nginx/nginx.conf ]
 	then
 		# one worker for each CPU and max 1024 connections/worker
@@ -471,7 +463,7 @@ END
 	# Setting up Nginx mapping
 	cat > "/etc/nginx/sites-available/$1.conf" <<END
 server {
-	listen 80;
+	listen [::]:80;
 	server_name www.$1 $1;
 	root /var/www/$1/public;
 	index index.html index.htm index.php;


### PR DESCRIPTION
I removed the "fix" where the IPv6 listener wouldn't conflict with the default nginx listener.

I believe that the Internet needs to be IPv6-ready, so I made this minor change. All sites will now be able to listen on IPv4 and IPv6. I think this also fixes issues with Debian wheezy (which doesn't need dotdeb, btw).
