### PR TITLE
Set Mysql to be UTF8

### DIFF
--- a/setup-debian.sh
+++ b/setup-debian.sh
@@ -247,8 +247,10 @@ query_cache_size = 0
 table_cache = 32
 
 init_connect='SET collation_connection = utf8_unicode_ci'
-character-set-server = utf8
-collation-server = utf8_unicode_ci
+init_connect='SET NAMES utf8' 
+character-set-server = utf8 
+collation-server = utf8_unicode_ci 
+skip-character-set-client-handshake
 
 default_storage_engine=MyISAM
 skip-innodb


### PR DESCRIPTION
From http://stackoverflow.com/a/9350444

Makes everything uft8_unicode_ci

+----------------------+-----------------+
| Variable_name        | Value           |
+----------------------+-----------------+
| collation_connection | utf8_unicode_ci |
| collation_database   | utf8_unicode_ci |
| collation_server     | utf8_unicode_ci |
+----------------------+-----------------+
