### PR TITLE
FastCGI changed from port to socket by default

### DIFF
--- a/setup-debian.sh
+++ b/setup-debian.sh
@@ -633,7 +633,7 @@ server {
     {
         try_files \$uri =404;
 
-        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_pass unix:/var/run/php5-fpm.sock;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME /var/www/$1/public\$fastcgi_script_name;
         include fastcgi_params;


### PR DESCRIPTION
FastCGI now uses the socket instead of the port. Might need a check if wheezy or squeeze or to change both fastcgi config and PHP config
