### PR TITLE
Change readme to include Debian 7 as well as 6

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-## Debian 6 VPS Script
+## Debian 6/7 VPS Script
 
 Remove excess packages (apache2, sendmail, bind9, samba, nscd, etc) and install the basic components needed for a light-weight HTTP(S) web server:
 


### PR DESCRIPTION
I think 7 should be included as it appears a bit misleading otherwise and people will think it only works on Debian 6.
