### PR TITLE
Add support for debian 7

### DIFF
--- a/setup-debian.sh
+++ b/setup-debian.sh
@@ -415,7 +415,7 @@ location ~ \.php$ {
 	fastcgi_temp_file_write_size 256k;
 	fastcgi_intercept_errors    on;
 	fastcgi_ignore_client_abort off;
-	fastcgi_pass 127.0.0.1:9000;
+	fastcgi_pass unix:/var/run/php5-fpm.sock;
 
 }
 # PHP search for file Exploit:


### PR DESCRIPTION
By default this script will not work with Debian 7, this is fixed by utilizing php-fpm's sock pass
