### PR TITLE
Restore PHP memory limit to 128MB

### DIFF
--- a/setup-debian.sh
+++ b/setup-debian.sh
@@ -324,13 +324,10 @@ END
 	if [ -f /etc/php5/fpm/php.ini ]
 		then
 			sed -i \
-				"s/upload_max_filesize = 2M/upload_max_filesize = 200M/" \
+				"s/upload_max_filesize = 2M/upload_max_filesize = 256M/" \
 				/etc/php5/fpm/php.ini
 			sed -i \
-				"s/post_max_size = 8M/post_max_size = 200M/" \
-				/etc/php5/fpm/php.ini
-			sed -i \
-				"s/memory_limit = 128M/memory_limit = 36M/" \
+				"s/post_max_size = 8M/post_max_size = 256M/" \
 				/etc/php5/fpm/php.ini
 	fi
 


### PR DESCRIPTION
Also increase post and upload max file size to 256MB
